### PR TITLE
address issue with gear ratio calculation

### DIFF
--- a/measure_thermal_behavior.py
+++ b/measure_thermal_behavior.py
@@ -87,13 +87,11 @@ def gather_metadata():
         rot_dist = config_z['rotation_distance']
         steps_per = config_z['full_steps_per_rotation']
         micro = config_z['microsteps']
+        gear_ratio = 1.
         if config_z['gear_ratio']:
-            gear_ratio_conf = config_z['gear_ratio']           
-            gear_ratio = float(gear_ratio_conf[0][0])
-            for reduction in gear_ratio_conf[1:]:
-                gear_ratio = gear_ratio/float(reduction)
-        else:
-            gear_ratio = 1.
+            gear_ratios = config_z['gear_ratio']
+            for ratio in gear_ratios:
+                gear_ratio = gear_ratio * ratio[0] / ratio[1]
         step_distance = (rot_dist / (micro * steps_per))/gear_ratio
     elif 'step_distance' in config_z.keys():
         step_distance = config_z['step_distance']


### PR DESCRIPTION
Apologies if I'm missing something here, but on my system, the gear ratio config contains a list of lists of two numbers and the divisor gets lost in the calculation.  For example, my config returns:
```
[[80.0, 16.0]]
```

The existing calculation would use `80` then iterate through the following ratios (none in this case) and lose the `16`.  If I configure two ratios, I get a crash:
```
Traceback (most recent call last):
  File "./measure_thermal_behavior.py", line 531, in <module>
    main()
  File "./measure_thermal_behavior.py", line 413, in main
    metadata = gather_metadata()
  File "./measure_thermal_behavior.py", line 94, in gather_metadata
    gear_ratio = gear_ratio/float(reduction)
TypeError: float() argument must be a string or a number, not 'list'
```

Hope this is helpful!