### PR TITLE
[BUGFIX] Bump matplotlib minimum version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib >= 3.3.0
+matplotlib >= 3.5.0
 numpy >= 1.16.0
 pandas >= 1.3.5
 rich >= 13.3.1


### PR DESCRIPTION
Matplotlib <3.5 is not compatible with Pandas 2.0 (which will get installed by default if it isn't available)
The error signature for a scenario with a too old matplotlib is this:
```
ValueError: Multi-dimensional indexing (e.g. `obj[:, None]`) is no longer supported. Convert to a numpy array before indexing instead.
```

Updating matplotlib to 3.5 or newer (testes 3.5.3 and 3.7.2) fixes the incompatibility.

Tested combinations:

Pandas 1.3.5 and matplotlib 3.3.4: OK
Pandas 1.3.5 and matplotlib 3.5.3: OK
Pandas 1.5.3 and matplotlib 3.3.4: OK
Pandas 1.5.3 and matplotlib 3.5.3: OK
Pandas 2.0.3 and matplotlib 3.3.4: FAIL
Pandas 2.0.3 and matplotlib 3.4.3: FAIL
Pandas 2.0.3 and matplotlib 3.5.3: OK
Pandas 2.0.3 and matplotlib 3.7.2: OK